### PR TITLE
Map fragment bug fix

### DIFF
--- a/Application/app/src/main/java/mx/itesm/incidentesatizapan/Menu.kt
+++ b/Application/app/src/main/java/mx/itesm/incidentesatizapan/Menu.kt
@@ -30,7 +30,10 @@ class Menu : AppCompatActivity() {
         // menu should be considered as top level destinations.
         val appBarConfiguration = AppBarConfiguration(
             setOf(
-                R.id.navigation_main, R.id.navigation_dashboard, R.id.navigation_notifications
+                R.id.navigation_main,
+                R.id.navigation_dashboard,
+                R.id.navigation_notifications,
+                R.id.navigation_map
             )
         )
         setupActionBarWithNavController(navController, appBarConfiguration)

--- a/Application/app/src/main/java/mx/itesm/incidentesatizapan/view/MapsFragment.kt
+++ b/Application/app/src/main/java/mx/itesm/incidentesatizapan/view/MapsFragment.kt
@@ -62,7 +62,10 @@ class MapsFragment : Fragment() {
 
     private fun setObservables() {
         viewModel.incidents.observe(viewLifecycleOwner) { incidents ->
-            addMarkers(incidents)
+            // Only add the markers if the map already exists
+            if (this::googleMap.isInitialized) {
+                addMarkers(incidents)
+            }
         }
     }
 


### PR DESCRIPTION
En clase me di cuenta de un bug en el que al abrir el mapa, cambiar de fragmento en el menú y regresar nuevamente al mapa, la aplicación se detenía por una excepción en la que se estaba intentando colocar marcadores antes de que existiera el objeto del mapa.

Por la forma en que está programado, esto no debería pasar, así que investigando encontré que el viewModel no se muere con el fragmento, sino que "sigue vivo" con la actividad (que en nuestro caso es toda la aplicación), y como el fragmento del mapa se destruye y se vuelve a crear, el viewModel le manda los datos que ya tenía (los de la primera vez que se creó el fragmento mapa) antes de crear el objeto del mapa (en el código se solicitan los datos después de que el mapa se creó). Esto pasa básicamente porque el viewModel nunca se murió.

No sé cómo adaptar el viewModel para que se destruya con el fragmento en vez de que siga deambulando allí, por lo que opté por la solución más sencilla: agregar un if preguntando si el mapa ya está creado, aunque no es lo óptimo. Al menos la aplicación ya no explota.